### PR TITLE
Remove condition resulting in recursive call

### DIFF
--- a/ViewController.m
+++ b/ViewController.m
@@ -45,12 +45,6 @@
      
      
      }
-     
-     else {
-     //do original thing
-     [self viewDidLoad];
-     
-     }
 
 }
 


### PR DESCRIPTION
if the condition on line 29 is false, `viewDidLoad` would have been recursively called. The comment, "do original thing" indicates the original behavior should be executed, however, the `super` call in the first line of the method (appropriately) yields that result. 